### PR TITLE
Fix shell expansion issues

### DIFF
--- a/templates/psql.mustache.sh
+++ b/templates/psql.mustache.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # Run database initialisation so that the desired tables exist
-psql "host={{{POSTGRESQL_HOST}}} port={{{POSTGRESQL_PORT}}} dbname={{{POSTGRESQL_DB_NAME}}} user={{{POSTGRESQL_USERNAME}}} password={{{POSTGRESQL_PASSWORD}}} sslmode=require" -f /app/resources/init_db.sql
+export PGPASSWORD='{{{POSTGRESQL_PASSWORD}}}'; psql -h '{{{POSTGRESQL_HOST}}}' -p '{{{POSTGRESQL_PORT}}}' -d '{{{POSTGRESQL_DB_NAME}}}' -U '{{{POSTGRESQL_USERNAME}}}' --set=sslmode=require -f /app/resources/init_db.sql
 
 # Run LDAP synchronisation
-psql "host={{{POSTGRESQL_HOST}}} port={{{POSTGRESQL_PORT}}} dbname={{{POSTGRESQL_DB_NAME}}} user={{{POSTGRESQL_USERNAME}}} password={{{POSTGRESQL_PASSWORD}}} sslmode=require" -f /app/resources/update_users.sql
+export PGPASSWORD='{{{POSTGRESQL_PASSWORD}}}'; psql -h '{{{POSTGRESQL_HOST}}}' -p '{{{POSTGRESQL_PORT}}}' -d '{{{POSTGRESQL_DB_NAME}}}' -U '{{{POSTGRESQL_USERNAME}}}' --set=sslmode=require -f /app/resources/update_users.sql


### PR DESCRIPTION
- Provide password through environment variable
- Use `psql` flags rather than a command string for `psql` commands

Closes #3