### PR TITLE
Allow anonymous LDAP bind

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Synchronise a Guacamole PostgreSQL database with an LDAP server, such as Microso
 
 ## Environment variables
 
-- LDAP_BIND_DN: Distinguished name of LDAP bind user
-- LDAP_BIND_PASSWORD: Password of LDAP bind user
+- LDAP_BIND_DN: (Optional) distinguished name of LDAP bind user
+- LDAP_BIND_PASSWORD: (Optional) password of LDAP bind user
 - LDAP_GROUP_BASE_DN: Base DN for groups
 - LDAP_GROUP_FILTER: LDAP filter to select groups
 - LDAP_HOST: LDAP host

--- a/templates/pg_ldap_sync.mustache.yaml
+++ b/templates/pg_ldap_sync.mustache.yaml
@@ -8,9 +8,14 @@ ldap_connection:
   host: {{{LDAP_HOST}}}
   port: {{{LDAP_PORT}}}
   auth:
+  {{#LDAP_BIND_DN}}
     method: :simple
     username: {{{LDAP_BIND_DN}}}
     password: {{{LDAP_BIND_PASSWORD}}}
+  {{/LDAP_BIND_DN}}
+  {{^LDAP_BIND_DN}}
+    method: :anonymous
+  {{/LDAP_BIND_DN}}
 
 # Search parameters for LDAP users which should be synchronized
 ldap_users:


### PR DESCRIPTION
Make LDAP_BIND_DN and LDAP_BIND_PASSWORD optional, defaulting to anonymous bind

Closes #7